### PR TITLE
ensured clean restart so that go plugin server gets a chance to start afresh

### DIFF
--- a/bin/app/heroku-buildpack-kong-web
+++ b/bin/app/heroku-buildpack-kong-web
@@ -14,5 +14,6 @@ if [ -e "$NGINX_TEMPLATE" ]
   NGINX_TEMPLATE_PARAM="--nginx-conf $NGINX_TEMPLATE"
 fi
 
+kong stop -p $APP_PREFIX
 kong prepare -p $APP_PREFIX -c $KONG_CONF $NGINX_TEMPLATE_PARAM
 eval "nginx -p $APP_PREFIX -c $APP_PREFIX/nginx.conf $@"

--- a/bin/compile
+++ b/bin/compile
@@ -302,7 +302,7 @@ fi
 
 # run kong post-build if available
 if [[ -f $BUILD_DIR/bin/kong-post-build ]]; then
-    echo "Running bin/kong-post-build hook"
+    echo "Running bin/kong-post-build hook" | indent
     chmod a+x $BUILD_DIR/bin/kong-post-build
     $BUILD_DIR/bin/kong-post-build $BUILD_DIR
 fi


### PR DESCRIPTION
**Observation**
Thanks to Load Testing I was able to discover a subtle issue when after a fresh deploy our plugin code would sometimes not trigger. This resulted in unexpected failure of certain requests.

**Root of the Problem**
The Go pluginserver wasn't gracefully restarting after a deploy

**Fix**
This PR fixes the issue by ensuring Kong stops before starting again after each deploy as stoping Kong stops the Go pluginserver as well

PS: Also this PR includes a formatting fix in the compile script (thanks @mobilutz for spotting that)
