### PR TITLE
revered kong stop

### DIFF
--- a/bin/app/heroku-buildpack-kong-web
+++ b/bin/app/heroku-buildpack-kong-web
@@ -14,6 +14,5 @@ if [ -e "$NGINX_TEMPLATE" ]
   NGINX_TEMPLATE_PARAM="--nginx-conf $NGINX_TEMPLATE"
 fi
 
-kong stop -p $APP_PREFIX
 kong prepare -p $APP_PREFIX -c $KONG_CONF $NGINX_TEMPLATE_PARAM
 eval "nginx -p $APP_PREFIX -c $APP_PREFIX/nginx.conf $@"


### PR DESCRIPTION
# Description #
This PR reverts the `kong stop` command as it's not needed any more with this [PR](https://github.com/riskmethods/heroku-kong/pull/3) and will cause problems if left alone because of the ephemeral nature of Heroku file system.

PS: This has already been on staging for some time now and has already been validated.