### PR TITLE
Add codeowners file

### DIFF
--- a/github/CODEOWNERS
+++ b/github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @riskmethods/team-meteor


### PR DESCRIPTION
As this repos is @riskmethods/team-meteor responsibility, lets write in in the CodeOwners file.

https://riskmethods.atlassian.net/wiki/spaces/METEOR/pages/56918063/Team+assets#Repositories

https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners